### PR TITLE
Add changelog, with an entry for November 2021

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Pulumi Console Requests Changelog
+
+The goal of this file is to provide a timely record of improvements we make in response to the public console
+requests tracker for the Pulumi Console.
+
+- We should update this file each time an issue from the `pulumi/console-requests` repo is addressed, adding
+  a note about whatever cool, new feature was added that month.
+- Please be descriptive enough so that somebody unfamiliar with the Pulumi Console codebase will
+  understand what new feature or ability was added. i.e. describe things in terms of what users
+  can do, and link to any relevant PRs or bugs for more context.
+
+## November, 2021
+
+- Add a "Copy to Clipboard" button for project and stack output and configuration values.  [#8](https://github.com/pulumi/console-requests/issues/8)


### PR DESCRIPTION
This PR adds a changelog for console-requests, and includes an entry for a recently pushed change.  I'll hold off from merging this until that change is live in prod (likely tomorrow) to keep it accurate.

This log takes some language from the Pulumi Console changelog - https://github.com/pulumi/pulumi-service/blob/master/CHANGELOG.md - but please feel free to make inline suggestions as you see fit!

Resolves https://github.com/pulumi/console-requests/issues/10